### PR TITLE
Activate GH Login

### DIFF
--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -253,7 +253,7 @@ def nospam(self):
 
 
 @library.global_function
-def provider_login_url(request, provider_id='fxa', **query):
+def provider_login_url(request, provider_id='github', **query):
     """
     This function adapts the django-allauth templatetags that don't support jinja2.
     @TODO: land support for the jinja2 tags in the django-allauth.

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -146,7 +146,7 @@ INSTALLED_APPS = (
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
-    'allauth.socialaccount.providers.fxa',
+    'allauth.socialaccount.providers.github',
     'notifications',
     'graphene_django',
     'webpack_loader',
@@ -807,7 +807,6 @@ CORS_URLS_REGEX = r'^/(pontoon\.js|graphql/?)$'
 SOCIALACCOUNT_ENABLED = True
 SOCIALACCOUNT_ADAPTER = 'pontoon.base.adapter.PontoonSocialAdapter'
 
-
 def account_username(user):
     return user.name_or_email
 
@@ -816,22 +815,6 @@ ACCOUNT_AUTHENTICATED_METHOD = 'email'
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_EMAIL_VERIFICATION = 'none'
 ACCOUNT_USER_DISPLAY = account_username
-
-# Firefox Accounts
-FXA_CLIENT_ID = os.environ.get('FXA_CLIENT_ID', '')
-FXA_SECRET_KEY = os.environ.get('FXA_SECRET_KEY', '')
-FXA_OAUTH_ENDPOINT = os.environ.get('FXA_OAUTH_ENDPOINT', '')
-FXA_PROFILE_ENDPOINT = os.environ.get('FXA_PROFILE_ENDPOINT', '')
-FXA_SCOPE = ['profile:uid', 'profile:display_name', 'profile:email']
-
-# All settings related to the AllAuth
-SOCIALACCOUNT_PROVIDERS = {
-    'fxa': {
-        'SCOPE': FXA_SCOPE,
-        'OAUTH_ENDPOINT': FXA_OAUTH_ENDPOINT,
-        'PROFILE_ENDPOINT': FXA_PROFILE_ENDPOINT,
-    }
-}
 
 # Defined all trusted origins that will be returned in pontoon.js file.
 if os.environ.get('JS_TRUSTED_ORIGINS'):


### PR DESCRIPTION
Removes FXA login and replaces it by GitHub login.

You need to add a SocialAccount model called 'github' through the admin interface (`https://pontoon.rust-lang.org/a`), giving it the app id and secret given by GitHub.